### PR TITLE
Inline functions without external linkage should be static

### DIFF
--- a/src/bitcask.c
+++ b/src/bitcask.c
@@ -99,12 +99,12 @@ Bitcask* bc_open2(Mgr *mgr, int depth, int pos, time_t before)
     return bc;
 }
 
-inline bool file_exists(const char *path) {
+static inline bool file_exists(const char *path) {
     struct stat st;
     return stat(path, &st) == 0;
 }
 
-inline char *gen_path(char *dst, const char *base, const char *fmt, int i)
+static inline char *gen_path(char *dst, const char *base, const char *fmt, int i)
 {
     static char path[256];
     char name[16];
@@ -114,7 +114,7 @@ inline char *gen_path(char *dst, const char *base, const char *fmt, int i)
     return dst;
 }
 
-inline char *new_path(char *dst, Mgr *mgr, const char *fmt, int i)
+static inline char *new_path(char *dst, Mgr *mgr, const char *fmt, int i)
 {
     char *path = gen_path(dst, mgr_base(mgr), fmt, i);
     if (!file_exists(dst)) {

--- a/src/codec.c
+++ b/src/codec.c
@@ -28,7 +28,7 @@ typedef struct {
     char fmt[7];
 } Fmt;
 
-inline int fmt_size(Fmt *fmt) {
+static inline int fmt_size(Fmt *fmt) {
     return sizeof(Fmt) + strlen(fmt->fmt) - 7 + 1;
 }
 

--- a/src/hstore.c
+++ b/src/hstore.c
@@ -45,14 +45,14 @@ struct t_hstore {
     Bitcask* bitcasks[];
 };
 
-inline int get_index(HStore *store, char *key)
+static inline int get_index(HStore *store, char *key)
 {
     if (store->height == 0) return 0;
     uint32_t h = fnv1a(key, strlen(key));
     return h >> ((8 - store->height) * 4);
 }
 
-inline pthread_mutex_t* get_mutex(HStore *store, char *key)
+static inline pthread_mutex_t* get_mutex(HStore *store, char *key)
 {
     uint32_t i = fnv1a(key, strlen(key)) % NUM_OF_MUTEX;
     return &store->locks[i];

--- a/src/htree.c
+++ b/src/htree.c
@@ -74,23 +74,23 @@ static void split_node(HTree *tree, Node *node);
 static void merge_node(HTree *tree, Node *node);
 static void update_node(HTree *tree, Node *node);
 
-inline uint32_t get_pos(HTree *tree, Node *node)
+static inline uint32_t get_pos(HTree *tree, Node *node)
 {
     return (node - tree->root) - g_index[(int)node->depth];
 }
 
-inline Node *get_child(HTree *tree, Node *node, int b)
+static inline Node *get_child(HTree *tree, Node *node, int b)
 {
     int i = g_index[node->depth + 1] + (get_pos(tree, node) << 4) + b;
     return tree->root + i;
 }
 
-inline Data* get_data(Node *node)
+static inline Data* get_data(Node *node)
 {
     return node->data;
 }
 
-inline void set_data(Node *node, Data *data)
+static inline void set_data(Node *node, Data *data)
 {
     if (data != node->data) {
         if (node->data) free(node->data);
@@ -98,7 +98,7 @@ inline void set_data(Node *node, Data *data)
     }
 }
 
-inline uint32_t key_hash(HTree *tree, Item* it)
+static inline uint32_t key_hash(HTree *tree, Item* it)
 {
     char buf[255];
     int n = dc_decode(tree->dc, buf, it->key, KEYLENGTH(it));
@@ -315,7 +315,7 @@ static Item* get_item_hash(HTree* tree, Node* node, Item* it, uint32_t keyhash)
     return r;
 }
 
-inline int hex2int(char b)
+static inline int hex2int(char b)
 {
     if (('0'<=b && b<='9') || ('a'<=b && b<='f')) {
         return (b>='a') ?  (b-'a'+10) : (b-'0');
@@ -690,7 +690,7 @@ void ht_destroy(HTree *tree)
     free(tree);
 }
 
-inline uint32_t keyhash(const char *s, int len)
+static inline uint32_t keyhash(const char *s, int len)
 {
     return fnv1a(s, len);
 }


### PR DESCRIPTION
Without `static`, beansdb may fail to compile under clang, though it works well with gcc.
